### PR TITLE
srcElement changed by target

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -149,7 +149,7 @@ var App = function()
         });
         // Event when the script is loaded:
         script.addEventListener('load', function(e){
-            var slug = e.srcElement.getAttribute('data-slug');
+            var slug = e.target.getAttribute('data-slug');
             for(var i in _this.totalViews)
             {
                 if(_this.totalViews[i].slug == slug) {


### PR DESCRIPTION
`srcElement` is a legacy Internet Explorer object used mainly on IE8-. For IE9+ and rest of browsers `target` must be used instead of `srcElement`. `srcElement` is not supported by any version of Firefox, so until now #plygrnd was not working on this browser due to a `TypeError` exception. More info: http://stackoverflow.com/questions/5301643/how-can-i-make-event-srcelement-work-in-firefox-and-what-does-it-mean
